### PR TITLE
Plugin fixed for Heka 0.10 and recycling for custom encoder

### DIFF
--- a/bq_output.go
+++ b/bq_output.go
@@ -127,12 +127,12 @@ func (bqo *BqOutput) Run(or OutputRunner, h PluginHelper) (err error) {
 				payload, err = or.Encode(pack)
 				if err != nil {
 					or.LogError(err)
-					pack.Recycle()
+					pack.Recycle(nil)
 					continue
 				}
 			} else {
 				payload = []byte(pack.Message.GetPayload())
-				pack.Recycle()
+				pack.Recycle(nil)
 			}
 
 			// Write to both file and buffer

--- a/bq_output.go
+++ b/bq_output.go
@@ -127,8 +127,11 @@ func (bqo *BqOutput) Run(or OutputRunner, h PluginHelper) (err error) {
 				if err != nil {
 					or.LogError(err)
 					pack.Recycle(err)
-					logUpdate(or, "Primer bucle")
+					logUpdate(or, "Primer bloque error distinto nil")
 					continue
+				}
+				else {
+					logUpdate(or, "Primer bloque error es nil")
 				}
 			} else {
 				payload = []byte(pack.Message.GetPayload())

--- a/bq_output.go
+++ b/bq_output.go
@@ -127,15 +127,13 @@ func (bqo *BqOutput) Run(or OutputRunner, h PluginHelper) (err error) {
 				if err != nil {
 					or.LogError(err)
 					pack.Recycle(err)
-					logUpdate(or, "Primer bloque error distinto nil")
 					continue
 				} else {
-					logUpdate(or, "Primer bloque error es nil")
+					pack.Recycle(nil)
 				}
 			} else {
 				payload = []byte(pack.Message.GetPayload())
 				pack.Recycle(nil)
-				logUpdate(or, "Segundo bloque")
 			}
 
 			// Write to both file and buffer

--- a/bq_output.go
+++ b/bq_output.go
@@ -126,7 +126,7 @@ func (bqo *BqOutput) Run(or OutputRunner, h PluginHelper) (err error) {
 				payload, err = or.Encode(pack)
 				if err != nil {
 					or.LogError(err)
-					pack.Recycle(nil)
+					pack.Recycle(err)
 					continue
 				}
 			} else {

--- a/bq_output.go
+++ b/bq_output.go
@@ -129,8 +129,7 @@ func (bqo *BqOutput) Run(or OutputRunner, h PluginHelper) (err error) {
 					pack.Recycle(err)
 					logUpdate(or, "Primer bloque error distinto nil")
 					continue
-				}
-				else {
+				} else {
 					logUpdate(or, "Primer bloque error es nil")
 				}
 			} else {

--- a/bq_output.go
+++ b/bq_output.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/tommyvicananza/heka-bigquery/bq"
+	bigquery "google.golang.org/api/bigquery/v2"
 
 	. "github.com/mozilla-services/heka/pipeline"
 )

--- a/bq_output.go
+++ b/bq_output.go
@@ -12,9 +12,7 @@ import (
 	"os"
 	"time"
 
-	"google.golang.org/api/bigquery/v2"
-
-	"github.com/aranair/heka-bigquery/bq"
+	"github.com/tommyvicananza/heka-bigquery/bq"
 
 	. "github.com/mozilla-services/heka/pipeline"
 )

--- a/bq_output.go
+++ b/bq_output.go
@@ -127,11 +127,13 @@ func (bqo *BqOutput) Run(or OutputRunner, h PluginHelper) (err error) {
 				if err != nil {
 					or.LogError(err)
 					pack.Recycle(err)
+					logUpdate(or, "Primer bucle")
 					continue
 				}
 			} else {
 				payload = []byte(pack.Message.GetPayload())
 				pack.Recycle(nil)
+				logUpdate(or, "Segundo bloque")
 			}
 
 			// Write to both file and buffer


### PR DESCRIPTION
I was trying to use heka-bigquery for saving my logs in bq. I am using Heka 0.10 version and also have Go 1.4.2.

The problem came when I wasn't able to install heka-bigquery because recycle pack. In Go 1.4.2 you need to send any parameter in recycle pack.

After fixing it, another trouble appeared, I was using a custom encoder and it stopped to send messages to bq, so I realized in heka-bigquery code wasn't recycling messages for custom encoders so I added recycle pack with this condition.
